### PR TITLE
Lock down version of rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gemspec
 
 gem 'rake'
 gem 'rspec'
-gem 'rubocop'
+gem 'rubocop', '~> 0.27.0'
 gem 'travis'
 gem 'coveralls'


### PR DESCRIPTION
Will probably want to do the same with other dev dependencies, but this
should get the build passing.