### PR TITLE
quick refactor to make a future pull request more focused

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ TrailingComma:
 AccessModifierIndentation:
   EnforcedStyle: outdent
 
+SingleLineBlockParams:
+  Enabled: false
+
 MethodLength:
   Max: 15
 

--- a/lib/email_repair/mechanic.rb
+++ b/lib/email_repair/mechanic.rb
@@ -34,9 +34,7 @@ module EmailRepair
     def repair(email)
       return unless email
 
-      repairs.each { |repair| email = repair.repair(email) }
-
-      email
+      repairs.reduce(email) { |memo, repair| repair.repair(memo) }
     end
 
     class CommonMistakeRepair


### PR DESCRIPTION
We can use `reduce` here to easily get the result of applying the transformations
without overwriting the original `email` variable.