### PR TITLE
Do not return duplicate 'good' emails when repairing a collection

### DIFF
--- a/lib/email_repair/mechanic.rb
+++ b/lib/email_repair/mechanic.rb
@@ -26,8 +26,8 @@ module EmailRepair
       end
 
       OpenStruct.new(
-        sanitized_emails: sanitized_emails,
-        invalid_emails: invalid_emails,
+        sanitized_emails: sanitized_emails.uniq,
+        invalid_emails: invalid_emails.uniq,
       )
     end
 

--- a/spec/lib/email_repair/mechanic_spec.rb
+++ b/spec/lib/email_repair/mechanic_spec.rb
@@ -5,9 +5,9 @@ module EmailRepair
 
     it 'sanitizes an array of emails and returns bulk results' do
       mechanic = Mechanic.new
-      salvageable_emails = %w(One@@two.com three@four.com)
+      salvageable_emails = %w(One@@two.com three@four.com one@twO.com)
       sanitized_emails = %w(one@two.com three@four.com)
-      bad_emails = %w(bleep@blop plooooooop)
+      bad_emails = %w(bleep@blop plooooooop plooOOooop)
 
       result = mechanic.repair_all(salvageable_emails + bad_emails)
       expect(result.sanitized_emails).to match_array sanitized_emails


### PR DESCRIPTION
If multiple "good" emails match, we should only take one.  This also dedupes
the bad emails, but without worrying about case sensitivity.