### PR TITLE
Filter out nil and empty string when bulk processing emails

### DIFF
--- a/lib/email_repair/mechanic.rb
+++ b/lib/email_repair/mechanic.rb
@@ -12,6 +12,8 @@ module EmailRepair
     end
 
     def repair_all(emails)
+      emails = emails.reject(&:nil?).map(&:strip).reject { |email| email == '' }
+
       sanitized_emails = []
       invalid_emails = []
 

--- a/lib/email_repair/version.rb
+++ b/lib/email_repair/version.rb
@@ -1,3 +1,3 @@
 module EmailRepair
-  VERSION = '0.0.3'
+  VERSION = '0.1.0'
 end

--- a/spec/lib/email_repair/mechanic_spec.rb
+++ b/spec/lib/email_repair/mechanic_spec.rb
@@ -14,6 +14,16 @@ module EmailRepair
       expect(result.invalid_emails).to match_array bad_emails
     end
 
+    it 'filters out nil and empty string emails before processing results' do
+      mechanic = Mechanic.new
+      emails = [nil, '', ' ', 'bleep@bloop.com']
+
+      result = mechanic.repair_all(emails)
+
+      expect(result.sanitized_emails).to eq ['bleep@bloop.com']
+      expect(result.invalid_emails).to eq []
+    end
+
   end
 
   describe Mechanic, '#repair' do


### PR DESCRIPTION
Seems harmless to filter these out.

Also bump the minor version on the gem so we can publish.