### PR TITLE
CodeQuality: Lengthen TLD wildcard matching for regex / repair

### DIFF
--- a/lib/email_repair/constants.rb
+++ b/lib/email_repair/constants.rb
@@ -4,7 +4,7 @@ module EmailRepair
       def email_regex
         local_part_regex = "[#{valid_chars}]" \
           "([#{valid_chars_with_dot}]*[#{valid_chars}])?"
-        /#{local_part_regex}@(?:[a-z0-9\-]+\.)+(?:museum|travel|[a-z]{2,4})/
+        /#{local_part_regex}@(?:[a-z0-9\-]+\.)+(?:[a-z]{2,24})/
       end
 
     private

--- a/lib/email_repair/mechanic.rb
+++ b/lib/email_repair/mechanic.rb
@@ -45,7 +45,7 @@ module EmailRepair
           .gsub(/\s/, '')
           .sub(/@+/, '@')
           .sub(/\.c0m$/, '.com')
-          .sub(/,[a-z]{2,4}$/) { |m| m.sub(',', '.') }
+          .sub(/,[a-z]{2,24}$/) { |m| m.sub(',', '.') }
       end
     end
 

--- a/spec/lib/email_repair/mechanic_spec.rb
+++ b/spec/lib/email_repair/mechanic_spec.rb
@@ -32,12 +32,17 @@ module EmailRepair
     it 'returns clean emails as is' do
       # Rant about apostrophe in email
       # http://www.stuffaboutcode.com/2013/02/validating-email-address-bloody.html
+      # List of longest TLDs
+      # https://jasontucker.blog/8945/what-is-the-longest-tld-you-can-get-for-a-domain-name
       good_emails = %w(
         b@b.com
         lobatifricha@gmail.com
         mrspicy+whocares@whatevs.com
         your.mom@the.museum
         martin.o'hanlon@mycompany.com
+        b@mps.school
+        b@kickstarter.engineering
+        b@joyful.christmas
       )
 
       good_emails.each do |good_email|


### PR DESCRIPTION
**What**
There are a few cases where longer TLDs are needed beyond the initial 4 characters
we allow. A list of all available domain names can be found using:

`curl -s http://data.iana.org/TLD/tlds-alpha-by-domain.txt | tail -n+2 | awk '{ print length(), $0 | "sort -n" }'`

via the terminal (right now longest is 24, so set it to that).

Same list is avail here: https://jasontucker.blog/8945/what-is-the-longest-tld-you-can-get-for-a-domain-name